### PR TITLE
fix: clean dock output

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tugboat
 Title: Build a Docker Image from a Directory or Project
-Version: 0.1.1
+Version: 0.1.2
 Authors@R: 
     person(given = "Daniel",
            family = "Molitor",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# tugboat 0.1.2
+
+- Added argument `verbose` to the `tugboat::create()` function. If
+`verbose = TRUE`, the resulting Dockerfile will be printed to the R console.
+
 # tugboat 0.1.1
 
 - In `tugboat::build()` the default value for the build_context is now

--- a/R/create.R
+++ b/R/create.R
@@ -59,5 +59,6 @@ create <- function(
     project = project
   )
   if (!is.null(as)) writeLines(dock, con = as)
-  return(dock)
+  cat(dock, sep = "\n")
+  invisible(dock)
 }

--- a/R/create.R
+++ b/R/create.R
@@ -24,6 +24,8 @@
 #'   all files in the directory will be included. NOTE: the file and directory
 #'   paths should be relative to the project directory. They do NOT need to
 #'   be absolute paths.
+#' @param verbose A boolean indicating whether or not to print the resulting
+#'   Dockerfile to the console. Default value is `FALSE`.
 #' 
 #' @seealso [here::here]; this will be used by default to determine the current
 #'   project directory.
@@ -49,7 +51,8 @@ create <- function(
   as = file.path(project, "Dockerfile"),
   FROM = NULL,
   ...,
-  exclude = NULL
+  exclude = NULL,
+  verbose = FALSE
 ) {
   lockfile <- init_renv(project = project, ...)
   dock <- dockerfile(lockfile, FROM = FROM)
@@ -59,6 +62,6 @@ create <- function(
     project = project
   )
   if (!is.null(as)) writeLines(dock, con = as)
-  cat(dock, sep = "\n")
+  if (verbose) cat(dock, sep = "\n")
   invisible(dock)
 }

--- a/man/create.Rd
+++ b/man/create.Rd
@@ -9,7 +9,8 @@ create(
   as = file.path(project, "Dockerfile"),
   FROM = NULL,
   ...,
-  exclude = NULL
+  exclude = NULL,
+  verbose = FALSE
 )
 }
 \arguments{
@@ -32,6 +33,9 @@ directories) that should NOT be included in the Docker image. By default,
 all files in the directory will be included. NOTE: the file and directory
 paths should be relative to the project directory. They do NOT need to
 be absolute paths.}
+
+\item{verbose}{A boolean indicating whether or not to print the resulting
+Dockerfile to the console. Default value is \code{FALSE}.}
 }
 \value{
 The Dockerfile contained as a string vector. Each vector element


### PR DESCRIPTION
A small refinement to the `create` command. It is currently returning a character vector and, therefore, printing it not as elegantly as it could be.

Consider adding `cat` first and returning the object invisibly. I.e., previously it was:

``` r
  library(tugboat)

create(
  project = here::here(),
  FROM = "rocker/r-ver:4.4.1",
  exclude = c("/data", "/figures", "/analysis", "/tables")
)
#> [1] "FROM rocker/r-ver:4.4.1"                                                                                                                                                                                                     
#> [2] "RUN mkdir -p /usr/local/lib/R/etc/ /usr/lib/R/etc/"                                                                                                                                                                          
#> [3] "RUN echo \"options(renv.config.pak.enabled = TRUE, repos = c(CRAN = 'https://cran.rstudio.com/'), download.file.method = 'libcurl', Ncpus = 4)\" | tee /usr/local/lib/R/etc/Rprofile.site | tee /usr/lib/R/etc/Rprofile.site"
#> [4] "RUN R -e \"install.packages('pak', repos = sprintf('https://r-lib.github.io/p/pak/stable/%s/%s/%s', .Platform[['pkgType']], R.Version()[['os']], R.Version()[['arch']]))\""                                                  
#> [5] "RUN R -e \"pak::pkg_install('renv@1.0.7')\""                                                                                                                                                                                 
#> [6] "COPY renv.lock renv.lock"                                                                                                                                                                                                    
#> [7] "RUN R -e \"renv::restore()\""                                                                                                                                                                                                
#> [8] "COPY . /reprex-6e202183305-alive-lark"                                                                                                                                                                                       
#> [9] ""
```

Now:

``` r
  library(tugboat)

create(
  project = here::here(),
  FROM = "rocker/r-ver:4.4.1",
  exclude = c("/data", "/figures", "/analysis", "/tables")
)

#> FROM rocker/r-ver:4.4.1
#> RUN mkdir -p /usr/local/lib/R/etc/ /usr/lib/R/etc/
#> RUN echo "options(renv.config.pak.enabled = TRUE, repos = c(CRAN = 'https://cran.rstudio.com/'), download.file.method = 'libcurl', Ncpus = 4)" | tee /usr/local/lib/R/etc/Rprofile.site | tee /usr/lib/R/etc/Rprofile.site
#> RUN R -e "install.packages('pak', repos = sprintf('https://r-lib.github.io/p/pak/stable/%s/%s/%s', .Platform[['pkgType']], R.Version()[['os']], R.Version()[['arch']]))"
#> RUN R -e "pak::pkg_install('renv@1.0.7')"
#> COPY renv.lock renv.lock
#> RUN R -e "renv::restore()"
#> COPY . /reprex-6e20150b72c7-rainy-quail
```

<sup>Created on 2025-01-11 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>
